### PR TITLE
[ShieldOps] Compose Generator Update

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,54 +1,58 @@
 version: '3.9'
-
 services:
-  web:
-    image: nginx:latest
-    container_name: sample_web
+  builder:
+    build:
+      context: .
+      dockerfile: Dockerfile
     ports:
-      - "8080:80"
-    environment:
-      NGINX_HOST: localhost
-      NGINX_PORT: 80
-    volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    - '22:22'
+    - 3306:3306
+    - 5432:5432
+    restart: unless-stopped
+    networks: &id001
+    - app-net
+    healthcheck:
+      test:
+      - CMD-SHELL
+      - curl -f http://localhost:22/health || exit 1
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    env_file:
+    - .env
+    user: 1000:1000
+    deploy:
+      resources:
+        limits:
+          cpus: '0.50'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 256M
     depends_on:
-      - api
-    restart: unless-stopped
-
-  api:
-    image: python:3.11-slim
-    container_name: sample_api
-    working_dir: /app
-    command: sh -c "python -m http.server 5000"
-    ports:
-      - "5000:5000"
+    - postgres
+  postgres:
+    image: postgres:16-alpine
     environment:
-      APP_ENV: development
-      DEBUG: "true"
-      SECRET_KEY: change-me-in-production
-    volumes:
-      - ./app:/app
-    restart: on-failure
-
-  db:
-    image: postgres:15
-    container_name: sample_db
-    environment:
-      POSTGRES_DB: shieldops
-      POSTGRES_USER: shieldops_user
-      POSTGRES_PASSWORD: weakpassword123
+      POSTGRES_DB: ${POSTGRES_DB:-appdb}
+      POSTGRES_USER: ${POSTGRES_USER:-app}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-secret}
     ports:
-      - "5432:5432"
+    - 5432:5432
     volumes:
-      - db_data:/var/lib/postgresql/data
-    restart: always
-
-  redis:
-    image: redis:7
-    container_name: sample_redis
-    ports:
-      - "6379:6379"
+    - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test:
+      - CMD-SHELL
+      - pg_isready -U ${POSTGRES_USER:-app} -d ${POSTGRES_DB:-appdb}
+      interval: 30s
+      timeout: 5s
+      retries: 5
     restart: unless-stopped
-
+    networks: *id001
+    env_file:
+    - .env
+networks:
+  app-net: {}
 volumes:
-  db_data:
+  pgdata: {}


### PR DESCRIPTION
# تقرير ShieldOps لمولد Compose

## Source
- Repository: mohammedabdallahcv-creator/docker-test-cicd
- Source Dockerfile: test_shieldops.dockerfile
- Generated artifact: docker-compose.yml

## Generation Summary
| Metric | Value |
| --- | ---: |
| Selected services | postgres |
| Security score | 78 |
| Reliability score | 89 |
| Resource readiness | Good |
| Warnings | 1 |

## Notes
- قم بتهيئة قيم POSTGRES_* داخل .env

## Scan Findings
- No scan findings attached.

## Generated Compose
```yaml
version: '3.9'
services:
  builder:
    build:
      context: .
      dockerfile: Dockerfile
    ports:
    - '22:22'
    - 3306:3306
    - 5432:5432
    restart: unless-stopped
    networks: &id001
    - app-net
    healthcheck:
      test:
      - CMD-SHELL
      - curl -f http://localhost:22/health || exit 1
      interval: 30s
      timeout: 5s
      retries: 3
    env_file:
    - .env
    user: 1000:1000
    deploy:
      resources:
        limits:
          cpus: '0.50'
          memory: 512M
        reservations:
          cpus: '0.25'
          memory: 256M
    depends_on:
    - postgres
  postgres:
    image: postgres:16-alpine
    environment:
      POSTGRES_DB: ${POSTGRES_DB:-appdb}
      POSTGRES_USER: ${POSTGRES_USER:-app}
      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-secret}
    ports:
    - 5432:5432
    volumes:
    - pgdata:/var/lib/postgresql/data
    healthcheck:
      test:
      - CMD-SHELL
      - pg_isready -U ${POSTGRES_USER:-app} -d ${POSTGRES_DB:-appdb}
      interval: 30s
      timeout: 5s
      retries: 5
    restart: unless-stopped
    networks: *id001
    env_file:
    - .env
networks:
  app-net: {}
volumes:
  pgdata: {}
```

---
*Generated by ShieldOps AI*

## Linked Issue
- https://github.com/mohammedabdallahcv-creator/docker-test-cicd/issues/69
- Closes #69